### PR TITLE
fix: add --client-id and --allow-no-subscriptions to az login

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -41,6 +41,8 @@ locals {
     nomad_upstream_tag_value = var.nomad_upstream_tag_value
     nomad_nodes              = var.nomad_nodes
     autopilot_health_enabled = var.autopilot_health_enabled
+
+    nomad_bootstrap_azure_client_id = azurerm_user_assigned_identity.nomad_vm_identity.client_id
   }
 }
 

--- a/templates/nomad_custom_data.sh.tpl
+++ b/templates/nomad_custom_data.sh.tpl
@@ -36,6 +36,7 @@ NOMAD_LOCATION="${nomad_location}"
 NOMAD_UI_ENABLED="${nomad_ui_enabled}"
 NOMAD_NODES="${nomad_nodes}"
 AUTOPILOT_HEALTH_ENABLED="${autopilot_health_enabled}"
+NOMAD_BOOTSTRAP_AZURE_CLIENT_ID="${nomad_bootstrap_azure_client_id}"
 
 
 function log {
@@ -473,7 +474,7 @@ function main {
     install_prereqs "$OS_DISTRO"
     install_azcli "$OS_DISTRO"
 		log "INFO" "Attempting Azure login using Managed Identity..."
-    if az login --identity &>/dev/null; then
+    if az login --identity --client-id "$NOMAD_BOOTSTRAP_AZURE_CLIENT_ID" --allow-no-subscriptions &>/dev/null; then
       log "INFO" "Azure login successful."
     else
       log "ERROR" "Azure login failed! Ensure the VM has a Managed Identity."


### PR DESCRIPTION
## Summary

Pass the managed identity client ID explicitly to `az login` and append `--allow-no-subscriptions` to tolerate identities with no subscription associations.

This aligns with the fix already applied in `terraform-azurerm-terraform-enterprise-hvd`.

## Changes

- `compute.tf`: Added `nomad_bootstrap_azure_client_id = azurerm_user_assigned_identity.nomad_vm_identity.client_id` to `local.custom_data_args`
- Template: Added `NOMAD_BOOTSTRAP_AZURE_CLIENT_ID` variable declaration
- Template: Updated `az login` to `az login --identity --client-id "$NOMAD_BOOTSTRAP_AZURE_CLIENT_ID" --allow-no-subscriptions`

## Why

Explicitly specifying `--client-id` ensures the correct managed identity is used when multiple identities are attached to a VM. The `--allow-no-subscriptions` flag prevents login failures when the identity has no subscription-level RBAC assignments (common for Key Vault-only access patterns).